### PR TITLE
Fix: Resolve Office.js module not found and type errors

### DIFF
--- a/src/utils/excelHelpers.ts
+++ b/src/utils/excelHelpers.ts
@@ -1,6 +1,5 @@
-/// <reference types="@types/office-js" />
-
-import Excel from 'office-js';
+// No import statement for office-js here.
+// We expect 'Excel' to be a global object provided by the Office environment and its types.
 
 export async function getWorksheetNames(): Promise<string[]> {
   try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["office-js", "node"],
+    "lib": ["dom", "dom.iterable", "esnext", "ScriptHost"]
   },
   "include": ["src"]
 } 


### PR DESCRIPTION
- Modified tsconfig.json to correctly include office-js types and necessary libs.
- Removed direct import of 'office-js' from excelHelpers.ts, relying on the global Excel object.
- Ensured the project builds successfully with these changes.